### PR TITLE
Added Dockerfiles for complete installation

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,0 +1,3 @@
+### List of contributors
+[trickster-is-weak](https://github.com/trickster-is-weak) (Web-Application)
+[Kalpesh Ahire](https://github.com/Kalpesh-18) (Dockerfiles)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM gradle:7.6.0-jdk17-alpine AS build
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle build --no-daemon
+
+FROM openjdk:18-jdk-slim
+
+EXPOSE 80
+
+RUN mkdir /app
+
+COPY --from=build /home/gradle/src/build/libs/surviving-0.6.war /app/spring-boot-application.war
+
+ENTRYPOINT ["java", "-jar","/app/spring-boot-application.war"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,51 @@ Version 0.6: 27/11/2022
 
 ## How do I install it?
 
+### Downloading the Code
+
+As should be said with any code run from the internet, there are risks involved. I haven't tested this on any machines
+but my own.
+This is the point where you are downloading and running software that is unverified and probably contains bugs.
+Java's Virtual Machine should prevent these bugs causing system instabilities, but I take no responsibility whatsoever.
+
+The complete code can be downloaded from the green "code" button on
+the [github page](https://github.com/trickster-is-weak/Surviving-Maps). You can then choose to download the code as a
+zip, or using git if you have that installed. After you have it downloaded and unzipped, open a Terminal/Command Prompt
+at this location.
+
+### Using docker
+If you have docker configured on your system the process to install this game is fairly simple. Just open a Terminal/Command Prompt
+at Surviving-Maps folder and execute the following command.
+
+```shell
+docker build --file=Dockerfile  -t SurvivingMaps .
+```
+You will notice the code getting compiled and may take few minutes to complete, this will happen only for the first time to generate docker image, also
+remember that this command should only be executed once just to create the image. After the compilation is successfull, execute the next command.
+
+```shell
+docker run -it -p 80:80 --name web SurvivingMaps
+```
+This command should be used everytime you want to start the game.
+
+This should start printing a load of stuff out on the screen such as files it's reading, and other logging information.
+
+When it stops, it will probably have something like 
+
+```shell
+[INFO ] 2022-11-10 19:53:38.431 [restartedMain] SpringApplication - Started SpringApplication in 10.892 seconds (JVM running for 12.011)
+<=======------> 60% EXECUTING [11m 59s]
+> :run
+```
+Now we can go to our browser and navigate to "http://localhost". This should load the splash page and the page is lauched successfuly.
+
+To exit, you can close the webpage and execute the following commands
+
+```shell
+docker kill web
+docker rm web
+```
+
 ### Precursors
 So the app needs things installed on your local machine before it will work: Java and Gradle.
 0. Some engineering spirit and appetite for risk
@@ -62,19 +107,6 @@ Ant:          Apache Ant(TM) version 1.10.11 compiled on July 10 2021
 JVM:          18.0.1.1 (Homebrew 18.0.1.1+0)
 OS:           Mac OS X 12.6.1 x86_64
 ```
-
-
-### Downloading the Code
-
-As should be said with any code run from the internet, there are risks involved. I haven't tested this on any machines
-but my own.
-This is the point where you are downloading and running software that is unverified and probably contains bugs.
-Java's Virtual Machine should prevent these bugs causing system instabilities, but I take no responsibility whatsoever.
-
-The complete code can be downloaded from the green "code" button on
-the [github page](https://github.com/trickster-is-weak/Surviving-Maps). You can then choose to download the code as a
-zip, or using git if you have that installed. After you have it downloaded and unzipped, open a Terminal/Command Prompt
-at this location.
 
 #### Verification
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ docker kill web
 docker rm web
 ```
 
+**If you don't have docker, use the following steps**
 ### Precursors
 So the app needs things installed on your local machine before it will work: Java and Gradle.
 0. Some engineering spirit and appetite for risk


### PR DESCRIPTION
To test, clone the code and run the following docker commands on terminal.

`docker build --file=Dockerfile  -t SurvivingMaps .`

This command will build the docker image during which the code would also get built. This command will take few minutes to execute as the jar file is getting. You have to create the image only once after that, each time container can be created quickly using the following command.

docker run -it -p 80:80 --name web SurvivingMaps

Check ["http://localhost"](http://localhost), attached an image of the same.

![image](https://user-images.githubusercontent.com/69343990/206861101-cbe653fa-a280-4913-9990-94f9b81d2c48.png)

To terminate the session, close the webpage and run the following commands on terminal
`docker kill web`

`docker rm web`